### PR TITLE
Fix typo in "time" variable; add plt.show()

### DIFF
--- a/ScalableExp.ipynb
+++ b/ScalableExp.ipynb
@@ -43,9 +43,9 @@
    "source": [
     "\n",
     "def walsh_percent_effect_remaining_at_time(time, action_duration):\n",
-    "    if t <= 0:\n",
+    "    if time <= 0:\n",
     "        return 1\n",
-    "    elif t >= action_duration:\n",
+    "    elif time >= action_duration:\n",
     "        return 0\n",
     "    \n",
     "    nearest_modeled_duration = None\n",
@@ -147,7 +147,8 @@
     "novolog_digitized = pd.read_csv('novolog_data.csv', index_col='time')\n",
     "scale = y.max() / novolog_digitized.max()\n",
     "plt.plot(novolog_digitized * scale, label=\"novolog digitized activity curve\", marker='o')\n",
-    "plt.legend(loc='upper right')"
+    "plt.legend(loc='upper right')\n",
+    "plt.show()"
    ]
   },
   {
@@ -199,7 +200,8 @@
     "loop_iob = np.array([walsh_percent_effect_remaining_at_time(t, dia) for t in x])\n",
     "plt.plot(x, loop_iob, label=\"walsh curve (dia=%0.0f)\" % dia)\n",
     "\n",
-    "plt.legend(loc='upper right')\n"
+    "plt.legend(loc='upper right')\n",
+    "plt.show()\n"
    ]
   }
  ],


### PR DESCRIPTION
The main fix is the `time` variable in the Walsh function, which was entered as `t` and caused an error that kept the notebook from running. 

The `plt.show()` commands are strictly cosmetic, but they suppress the matplotlib return messages you see above the plots. (Each cell in a notebook always displays the return value of the final command in the cell, and for plots, most plotting commands return some sort of object, e.g. `matplotlib.legend.Legend`, but `plt.show()` doesn't, so the output is a bit cleaner.)